### PR TITLE
feat: support tray icon spritesheets

### DIFF
--- a/electron/tray-list.ts
+++ b/electron/tray-list.ts
@@ -5,6 +5,9 @@ import fs from 'fs'
 import path from 'path'
 
 const supportedTrayIconExtensions = new Set(['.png', '.ico', '.jpg', '.jpeg', '.webp'])
+const spriteSheetManifestNames = ['pet.json', 'tray-icon.json', 'sprite.json']
+const defaultSpriteSheetColumns = 8
+const defaultSpriteSheetRows = 9
 const trayIconExtensionPriority = ['.png', '.webp', '.jpg', '.jpeg', '.ico']
 const builtinTrayIconDirectory = getPublicAssetPath('icons')
 const customTrayIconDirectory = path.join(getWallpaperRootPath(), 'tray-icons')
@@ -21,6 +24,32 @@ export type TrayIconSetDescriptor = {
   name: string
   previewPath: string
   source: TrayIconSource
+  spriteSheet?: TrayIconSpriteSheetDescriptor
+}
+
+export type TrayIconSpriteSheetDescriptor = {
+  columns: number
+  frameHeight: number
+  frameWidth: number
+  path: string
+  row: number
+  rows: number
+}
+
+type SpriteSheetManifest = {
+  columns?: number
+  defaultAnimation?: string
+  displayName?: string
+  frameHeight?: number
+  frameWidth?: number
+  id?: string
+  rows?: number
+  spriteSheetPath?: string
+  spritesheetPath?: string
+  states?: Record<string, number | { row?: number }>
+  tray?: { animation?: string; row?: number }
+  trayAnimation?: string
+  trayRow?: number
 }
 
 export type TrayIconSet = TrayIconSetDescriptor & {
@@ -63,6 +92,136 @@ function parseFrameCandidate(directoryName: string, fileName: string): FrameCand
   }
 }
 
+function readSpriteSheetManifest(directoryPath: string): SpriteSheetManifest | null {
+  for (const manifestName of spriteSheetManifestNames) {
+    const manifestPath = path.join(directoryPath, manifestName)
+
+    if (!fs.existsSync(manifestPath)) {
+      continue
+    }
+
+    try {
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as SpriteSheetManifest
+      return manifest && typeof manifest === 'object' ? manifest : null
+    } catch (error) {
+      console.warn(`[tray] sprite manifest could not be parsed: ${manifestPath}`, error)
+    }
+  }
+
+  return null
+}
+
+function getManifestSpriteSheetPath(manifest: SpriteSheetManifest | null, directoryPath: string) {
+  const spriteSheetPath = manifest?.spritesheetPath || manifest?.spriteSheetPath
+
+  if (!spriteSheetPath) {
+    return ''
+  }
+
+  return path.isAbsolute(spriteSheetPath) ? spriteSheetPath : path.join(directoryPath, spriteSheetPath)
+}
+
+function findSpriteSheetPath(directoryPath: string, entries: fs.Dirent[], manifest: SpriteSheetManifest | null) {
+  const manifestSpriteSheetPath = getManifestSpriteSheetPath(manifest, directoryPath)
+
+  if (manifestSpriteSheetPath && fs.existsSync(manifestSpriteSheetPath)) {
+    return manifestSpriteSheetPath
+  }
+
+  const spriteSheetEntry = entries
+    .filter((entry) => entry.isFile())
+    .find((entry) => {
+      const extension = path.extname(entry.name).toLowerCase()
+      const stem = path.basename(entry.name, extension).toLowerCase()
+      return supportedTrayIconExtensions.has(extension) && ['spritesheet', 'sprite-sheet', 'sprite_sheet', 'atlas'].includes(stem)
+    })
+
+  return spriteSheetEntry ? path.join(directoryPath, spriteSheetEntry.name) : ''
+}
+
+function getSpriteSheetRow(manifest: SpriteSheetManifest | null, rows: number) {
+  const requestedAnimation = manifest?.tray?.animation || manifest?.trayAnimation || manifest?.defaultAnimation
+  const requestedState = requestedAnimation ? manifest?.states?.[requestedAnimation] : undefined
+  const rowFromState = typeof requestedState === 'number' ? requestedState : requestedState?.row
+  const row = manifest?.tray?.row ?? manifest?.trayRow ?? rowFromState ?? 0
+
+  return Math.min(Math.max(Math.floor(row), 0), Math.max(rows - 1, 0))
+}
+
+function createSpriteSheetImages(spriteSheetPath: string, frameWidth: number, frameHeight: number, columns: number, row: number) {
+  const spriteSheet = nativeImage.createFromPath(spriteSheetPath)
+
+  if (spriteSheet.isEmpty()) {
+    console.warn(`[tray] sprite sheet could not be loaded: ${spriteSheetPath}`)
+    return []
+  }
+
+  return Array.from({ length: columns }, (_, column) =>
+    spriteSheet.crop({ height: frameHeight, width: frameWidth, x: column * frameWidth, y: row * frameHeight }).resize({ height: 24 }),
+  ).filter((image) => !image.isEmpty())
+}
+
+function createSpriteSheetTrayIconSet(
+  source: TrayIconSource,
+  directoryName: string,
+  directoryPath: string,
+  manifest: SpriteSheetManifest | null,
+  entries: fs.Dirent[],
+) {
+  const spriteSheetPath = findSpriteSheetPath(directoryPath, entries, manifest)
+
+  if (!spriteSheetPath) {
+    return null
+  }
+
+  const spriteSheet = nativeImage.createFromPath(spriteSheetPath)
+  if (spriteSheet.isEmpty()) {
+    console.warn(`[tray] sprite sheet could not be loaded: ${spriteSheetPath}`)
+    return null
+  }
+
+  const size = spriteSheet.getSize()
+  const columns = Math.max(1, Math.floor(manifest?.columns || defaultSpriteSheetColumns))
+  const rows = Math.max(1, Math.floor(manifest?.rows || defaultSpriteSheetRows))
+  const frameWidth = Math.floor(manifest?.frameWidth || size.width / columns)
+  const frameHeight = Math.floor(manifest?.frameHeight || size.height / rows)
+
+  if (!frameWidth || !frameHeight || frameWidth * columns > size.width || frameHeight * rows > size.height) {
+    console.warn(`[tray] sprite sheet dimensions are invalid: ${spriteSheetPath}`)
+    return null
+  }
+
+  const row = getSpriteSheetRow(manifest, rows)
+  const images = createSpriteSheetImages(spriteSheetPath, frameWidth, frameHeight, columns, row)
+
+  if (!images.length) {
+    return null
+  }
+
+  const name = manifest?.displayName || manifest?.id || directoryName
+
+  return {
+    directory: directoryPath,
+    frameCount: images.length,
+    framePaths: [spriteSheetPath],
+    id: `${source}:${directoryName}:${name}:spritesheet:${row}`,
+    images,
+    label: name,
+    lastModifiedAt: getTrayIconLastModifiedAt([spriteSheetPath]),
+    name,
+    previewPath: spriteSheetPath,
+    source,
+    spriteSheet: {
+      columns,
+      frameHeight,
+      frameWidth,
+      path: spriteSheetPath,
+      row,
+      rows,
+    },
+  } satisfies TrayIconSet
+}
+
 function createNativeImageFromAbsolutePath(assetPath: string) {
   if (!fs.existsSync(assetPath)) {
     console.warn(`[tray] icon not found: ${assetPath}`)
@@ -92,9 +251,8 @@ function ensureTrayIconDirectories() {
   fs.mkdirSync(customTrayIconDirectory, { recursive: true })
 }
 
-function collectTrayFrames(directoryName: string, directoryPath: string) {
+function collectTrayFrames(directoryName: string, directoryPath: string, entries = fs.readdirSync(directoryPath, { withFileTypes: true })) {
   const groups = new Map<string, Map<string, FrameCandidate[]>>()
-  const entries = fs.readdirSync(directoryPath, { withFileTypes: true })
 
   for (const entry of entries) {
     if (!entry.isFile()) {
@@ -143,7 +301,15 @@ function createTrayIconSet(source: TrayIconSource, directoryName: string, groupN
 }
 
 function getTrayIconSetsFromDirectory(source: TrayIconSource, directoryName: string, directoryPath: string) {
-  const frameGroups = collectTrayFrames(directoryName, directoryPath)
+  const entries = fs.readdirSync(directoryPath, { withFileTypes: true })
+  const manifest = readSpriteSheetManifest(directoryPath)
+  const spriteSheetIconSet = createSpriteSheetTrayIconSet(source, directoryName, directoryPath, manifest, entries)
+
+  if (spriteSheetIconSet) {
+    return [spriteSheetIconSet]
+  }
+
+  const frameGroups = collectTrayFrames(directoryName, directoryPath, entries)
   const iconSets: TrayIconSet[] = []
 
   for (const [groupName, groupFrames] of frameGroups.entries()) {
@@ -226,7 +392,7 @@ export function getTrayIconSets() {
 }
 
 export function getTrayIconSetDescriptors() {
-  return getTrayIconSets().map(({ images, ...item }) => item)
+  return getTrayIconSets().map(({ images: _images, ...item }) => item)
 }
 
 export function getDefaultTrayIconId() {
@@ -251,6 +417,39 @@ export function importTrayIconSet(name: string, framePaths: string[]) {
   const destinationDirectory = path.join(customTrayIconDirectory, normalizedName)
   fs.rmSync(destinationDirectory, { force: true, recursive: true })
   fs.mkdirSync(destinationDirectory, { recursive: true })
+
+  if (validFramePaths.length === 1) {
+    const sourcePath = validFramePaths[0]
+    const sourceImage = nativeImage.createFromPath(sourcePath)
+    const size = sourceImage.getSize()
+    const isLikelyCodexSpriteSheet =
+      !sourceImage.isEmpty() && size.width % defaultSpriteSheetColumns === 0 && size.height % defaultSpriteSheetRows === 0
+
+    if (isLikelyCodexSpriteSheet) {
+      const extension = path.extname(sourcePath).toLowerCase() || '.png'
+      const spriteSheetFileName = `spritesheet${extension}`
+      fs.copyFileSync(sourcePath, path.join(destinationDirectory, spriteSheetFileName))
+      fs.writeFileSync(
+        path.join(destinationDirectory, 'pet.json'),
+        JSON.stringify(
+          {
+            columns: defaultSpriteSheetColumns,
+            displayName: normalizedName,
+            frameHeight: size.height / defaultSpriteSheetRows,
+            frameWidth: size.width / defaultSpriteSheetColumns,
+            id: normalizedName,
+            rows: defaultSpriteSheetRows,
+            spritesheetPath: spriteSheetFileName,
+            tray: { row: 0 },
+          },
+          null,
+          2,
+        ),
+      )
+
+      return getTrayIconSetsFromDirectory('custom', normalizedName, destinationDirectory)[0] || null
+    }
+  }
 
   validFramePaths.forEach((framePath, index) => {
     const extension = path.extname(framePath).toLowerCase() || '.png'

--- a/src/pages/Setting/TrayIconPanel.tsx
+++ b/src/pages/Setting/TrayIconPanel.tsx
@@ -7,6 +7,15 @@ import { toast } from 'sonner'
 
 type TrayIconSource = 'builtin' | 'custom'
 
+type TrayIconSpriteSheet = {
+  columns: number
+  frameHeight: number
+  frameWidth: number
+  path: string
+  row: number
+  rows: number
+}
+
 type TrayIconItem = {
   directory: string
   frameCount: number
@@ -16,6 +25,7 @@ type TrayIconItem = {
   name: string
   previewPath: string
   source: TrayIconSource
+  spriteSheet?: TrayIconSpriteSheet
 }
 
 type TrayIconListResponse = {
@@ -48,6 +58,13 @@ function inferTrayIconName(files: File[]) {
 
 function getTrayIconSourceLabel(source: TrayIconSource) {
   return source === 'builtin' ? '内置' : '自定义'
+}
+
+function getSpriteBackgroundPosition(currentFrame: number, spriteSheet: TrayIconSpriteSheet) {
+  const x = spriteSheet.columns <= 1 ? 0 : (currentFrame / (spriteSheet.columns - 1)) * 100
+  const y = spriteSheet.rows <= 1 ? 0 : (spriteSheet.row / (spriteSheet.rows - 1)) * 100
+
+  return `${x}% ${y}%`
 }
 
 export default function TrayIconPanel() {
@@ -217,7 +234,8 @@ export default function TrayIconPanel() {
             <div>
               <p className='text-[14px] font-medium text-[var(--text-primary)]'>图标库与目录</p>
               <p className='mt-1 text-[12px] leading-5 text-[var(--text-tertiary)]'>
-                内置图标会自动扫描 public/icons，自定义图标会扫描用户目录。每个子文件夹代表一组动画帧，系统按文件名顺序播放。
+                内置图标会自动扫描 public/icons，自定义图标会扫描用户目录。每个子文件夹可以是一组切割好的动画帧，也可以是带 pet.json 的 Codex
+                精灵图；精灵图会按格子裁切后播放。
               </p>
             </div>
 
@@ -253,7 +271,7 @@ export default function TrayIconPanel() {
           <div className='mb-3'>
             <p className='text-[14px] font-medium text-[var(--text-primary)]'>导入一组自定义动画帧</p>
             <p className='mt-1 text-[12px] leading-5 text-[var(--text-tertiary)]'>
-              选择一组 PNG / ICO / JPG / WebP 图片帧，应用会自动复制到自定义图标目录，并在这里提供预览与切换。
+              选择一组 PNG / ICO / JPG / WebP 图片帧，或直接选择一张 Codex Pet 风格的精灵图；应用会复制到自定义图标目录，并提供预览与切换。
             </p>
           </div>
 
@@ -268,7 +286,7 @@ export default function TrayIconPanel() {
             />
             <Button variant='outline' size='sm' className='shrink-0' onClick={() => fileInputRef.current?.click()}>
               <ImagePlus className='mr-1.5 h-3.5 w-3.5' />
-              选择动画帧
+              选择动画帧/精灵图
             </Button>
             <Button size='sm' className='shrink-0' loading={importing} onClick={() => void handleImport()}>
               {!importing && <ImagePlus className='mr-1.5 h-3.5 w-3.5' />}
@@ -295,8 +313,10 @@ export default function TrayIconPanel() {
         ) : items.length ? (
           <div className='grid gap-3 md:grid-cols-2 xl:grid-cols-3'>
             {items.map((item) => {
-              const framePath = item.framePaths.length ? item.framePaths[previewTick % item.framePaths.length] : item.previewPath
+              const currentFrame = previewTick % Math.max(item.frameCount, 1)
+              const framePath = item.framePaths.length ? item.framePaths[currentFrame % item.framePaths.length] : item.previewPath
               const previewSrc = framePath ? toRendererFileUrl(framePath) : ''
+              const spritePreviewSrc = item.spriteSheet?.path ? toRendererFileUrl(item.spriteSheet.path) : ''
               const isActive = item.id === currentId
 
               return (
@@ -314,6 +334,7 @@ export default function TrayIconPanel() {
                       <p className='text-[14px] font-medium text-[var(--text-primary)]'>{item.label}</p>
                       <p className='mt-1 text-[12px] text-[var(--text-tertiary)]'>
                         {getTrayIconSourceLabel(item.source)} · {item.frameCount} 帧
+                        {item.spriteSheet ? ` · 精灵图 ${item.spriteSheet.columns}×${item.spriteSheet.rows}` : ''}
                       </p>
                     </div>
                     <span
@@ -327,7 +348,19 @@ export default function TrayIconPanel() {
                   </div>
 
                   <div className='mb-3 flex h-24 items-center justify-center rounded-xl border border-[var(--border-subtle)] bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.14),transparent_55%),rgba(2,6,23,0.35)]'>
-                    {previewSrc ? (
+                    {item.spriteSheet && spritePreviewSrc ? (
+                      <div
+                        aria-label={item.label}
+                        role='img'
+                        className='h-14 bg-no-repeat [image-rendering:pixelated]'
+                        style={{
+                          aspectRatio: `${item.spriteSheet.frameWidth} / ${item.spriteSheet.frameHeight}`,
+                          backgroundImage: `url(${spritePreviewSrc})`,
+                          backgroundPosition: getSpriteBackgroundPosition(currentFrame, item.spriteSheet),
+                          backgroundSize: `${item.spriteSheet.columns * 100}% ${item.spriteSheet.rows * 100}%`,
+                        }}
+                      />
+                    ) : previewSrc ? (
                       <img src={previewSrc} alt={item.label} className='h-14 w-auto object-contain [image-rendering:pixelated]' />
                     ) : (
                       <span className='text-[12px] text-[var(--text-tertiary)]'>暂无预览</span>
@@ -366,7 +399,7 @@ export default function TrayIconPanel() {
           <div className='rounded-xl border border-dashed border-[var(--border-subtle)] px-4 py-10 text-center'>
             <p className='text-[14px] font-medium text-[var(--text-primary)]'>还没有可用的菜单栏动态图标</p>
             <p className='mt-2 text-[12px] leading-5 text-[var(--text-tertiary)]'>
-              把动画帧放进 public/icons 的子文件夹里，或者导入一组自定义图片帧，然后点击刷新。
+              把切割好的动画帧或 Codex Pet 精灵图放进 public/icons 的子文件夹里，或者导入自定义图片后点击刷新。
             </p>
           </div>
         )}


### PR DESCRIPTION
### Motivation
- 支持 Codex Pet 风格的整图精灵图（spritesheet）作为托盘动态图标来源，方便直接使用一张整图而不是切好的帧。 
- 保留并兼容现有按文件名顺序播放的切割帧目录方案。 

### Description
- 在 `electron/tray-list.ts` 中新增 spritesheet 支持：查找 `pet.json`/`tray-icon.json`/`sprite.json` manifest、解析配置、按 manifest 或默认网格（默认 8×9）计算格子并用 `nativeImage.crop()` 生成每帧 `NativeImage`。 
- 在同一文件中新增 spritesheet 探测与构建逻辑，并在 `getTrayIconSetsFromDirectory` 中优先返回精灵图集（否则回退到原有多文件帧逻辑）。 
- 在 `importTrayIconSet` 中加入单张精灵图导入辅助：当只选择一张图且尺寸符合默认网格时会复制图片并生成本地 `pet.json`（方便用户直接导入整张精灵图）。 
- 在设置面板 `src/pages/Setting/TrayIconPanel.tsx` 中展示精灵图信息并增加预览：若为精灵图则用 `background-image` + `background-position`/`background-size` 做 CSS 定位预览，保留原有切割帧的 `<img>` 预览路径和交互。 

### Testing
- 已在仓库运行构建：`pnpm build:electron && pnpm build:web`，两端构建均成功。 
- 运行静态检查：`pnpm lint`，通过（仓库已有若干 warnings，但无新增错误）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0286ca36d88333952ac4cda5357d49)